### PR TITLE
Update for 1.11

### DIFF
--- a/bytebuffer.inc
+++ b/bytebuffer.inc
@@ -207,7 +207,7 @@ methodmap ByteBuffer {
 	}
 }
 
-ByteBuffer CreateByteBuffer(bool littleEndian = true, const char data[] = "", int dataSize = 0) {
+ByteBuffer CreateByteBuffer(bool littleEndian = true, const char[] data = "", int dataSize = 0) {
 	int id = -1;
 	for(int i = 0; i < MAX_BUFFERS; i++) {
 		if(!g_InUse[i]) {


### PR DESCRIPTION
Fixes
```
./include/bytebuffer.inc(210) : error 183: brackets after variable name indicates a fixed-size array, but size is missing or not constant
```